### PR TITLE
dy update to display text symbol similar to how it will display when printed through GP Server

### DIFF
--- a/esri.symbol.MultiLineTextSymbol.js
+++ b/esri.symbol.MultiLineTextSymbol.js
@@ -42,7 +42,7 @@ require(["esri/symbols/TextSymbol", "dojox/gfx/svg"], function(ts, svg)
 				for(var i = 0, n = texts.length; i < n; i++)
 				{ 
 					var tspan = (document.createElementNS ? document.createElementNS(dojox.gfx.svg.xmlns.svg, "tspan") : document.createElement("tspan"));
-					tspan.setAttribute("dy", i ? lineHeight : -(texts.length-1)*lineHeight/2); 
+					tspan.setAttribute("dy", i ? lineHeight : ""; 
 					tspan.setAttribute("x", s.x);
 					tspan.appendChild((dojox.gfx.useSvgWeb ? document.createTextNode(texts[i], true) : document.createTextNode(texts[i]))); 
 					r.appendChild(tspan);


### PR DESCRIPTION
I've been utilizing this for a notes widget in a WAB app.  Setting the first tspan to null, seems to display the text symbols closer to how they will display through the print widget (using GP Server).  Is there a reason you used " -(texts.length-1)*lineHeight/2); " or would you see any issue setting this as null?

Thanks